### PR TITLE
phpunit.xml: allowed output during tests 

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         colors="true"
         beStrictAboutTestsThatDoNotTestAnything="true"
-        beStrictAboutOutputDuringTests="true"
         beStrictAboutChangesToGlobalState="true"
         enforceTimeLimit="true"
 >


### PR DESCRIPTION
Allowed output during tests because it's a major obstacle during debugging.