### PR TITLE
CS/CI updates, Makefile switch

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,25 @@
+<?php
+
+use Phan\Issue;
+
+return [
+    'target_php_version' => '7.1',
+    'backward_compatibility_checks' => false,
+    'exclude_analysis_directory_list' => [
+        'vendor/',
+    ],
+    'plugins' => [
+        'AlwaysReturnPlugin',
+        'DollarDollarPlugin',
+        'DuplicateArrayKeyPlugin',
+        'PregRegexCheckerPlugin',
+        'PrintfCheckerPlugin',
+        'UnreachableCodePlugin',
+    ],
+    'directory_list' => [
+        'src/',
+    ],
+    'suppress_issue_types' => [
+        'PhanParamTooManyInternal',
+    ],
+];

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,61 @@
+<?php
+
+$header = <<<'EOF'
+Copyright 2018 Henrique Borba and contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+EOF;
+
+$existingConventions = [
+    'phpdoc_no_package' => false,
+    'phpdoc_separation' => false,
+    'phpdoc_summary' => false,
+    'phpdoc_align' => false,
+    'phpdoc_scalar' => false,
+    'phpdoc_no_empty_return' => false,
+    'phpdoc_annotation_without_dot' => false,
+    'phpdoc_no_alias_tag' => false,
+    'phpdoc_order' => false,
+    'ordered_imports' => false,
+];
+
+$finder = \PhpCsFixer\Finder::create()
+   ->in('src')
+   ->in('tests')
+   ->exclude('build')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        //'declare_strict_types' => true,
+        'explicit_indirect_variable' => true,
+        'no_superfluous_elseif' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => false,
+        'non_printable_character' => true,
+        'ordered_imports' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_order' => true,
+        'visibility_required' => true,
+        'header_comment' => ['header' => $header, 'separate' => 'bottom', 'location' => 'after_open'],
+        'ternary_to_null_coalescing' => true,
+        'yoda_style' => null,
+
+    ] + $existingConventions)
+    ->setFinder($finder)
+;

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    excludes_analyse:
+        - %currentWorkingDirectory%/tests/Broken.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,4 @@ before_script:
 script:
     - cd $TRAVIS_BUILD_DIR
     - make ci --keep-going COMPOSER='/bin/sh -c composer'
+    - composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,3 @@ before_script:
 script:
     - cd $TRAVIS_BUILD_DIR
     - vendor/bin/phpunit
-    - ./vendor/bin/phpcs ./src/ --standard=PSR1 --ignore=src/PHPSci/Kernel/PropertiesProcessor
-    - ./vendor/bin/phpcs ./src/ --standard=PSR2 --ignore=src/PHPSci/Kernel/PropertiesProcessor

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
     apt: true
 
 install:
+  - pecl install ast
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --no-interaction --ignore-platform-reqs
 
@@ -35,4 +36,4 @@ before_script:
 
 script:
     - cd $TRAVIS_BUILD_DIR
-    - vendor/bin/phpunit
+    - make ci --keep-going COMPOSER='/bin/sh -c composer'

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SILENT= # disabled $(shell which chronic)
 # PHP CS Fixer
 PHP_CS_FIXER=build/php-cs-fixer-v2.phar
 PHP_CS_FIXER_ARGS=--cache-file=build/cache/.php_cs.cache --verbose
+export PHP_CS_FIXER_IGNORE_ENV=1
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ all: test
 
 ci: SILENT=
 ci: prerequisites ci-phpunit ci-analyze
-	$(SILENT) $(COMPOSER) validate --strict || true
 
 ci-phpunit: ci-cs
 	$(SILENT) $(PHP) $(PHPUNIT) $(PHPUNIT_ARGS)
@@ -63,7 +62,7 @@ ci-cs: prerequisites
 ##############################################################
 
 test: phpunit analyze
-	$(SILENT) $(COMPOSER) validate --strict || true
+	$(SILENT) $(COMPOSER) validate || true
 
 test-prerequisites: prerequisites composer.lock
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,152 @@
+.PHONY: ci test prerequisites
+
+# Use any most recent PHP version
+PHP=$(shell which php7.2 || which php7.1 || which php)
+
+# Default parallelism
+JOBS=$(shell nproc)
+
+# Default silencer if installed
+SILENT= # disabled $(shell which chronic)
+
+# PHP CS Fixer
+PHP_CS_FIXER=build/php-cs-fixer-v2.phar
+PHP_CS_FIXER_ARGS=--cache-file=build/cache/.php_cs.cache --verbose
+
+# PHPUnit
+PHPUNIT=vendor/bin/phpunit
+PHPUNIT_ARGS=--coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
+
+# Phan
+PHAN=build/phan.phar
+PHAN_ARGS=-j $(JOBS) --allow-polyfill-parser
+PHAN_PHP_VERSION=7.1
+export PHAN_DISABLE_XDEBUG_WARN=1
+
+# PHPStan
+PHPSTAN=build/phpstan.phar
+PHPSTAN_ARGS=analyse src tests --level=2 -c .phpstan.neon
+
+# Composer
+COMPOSER=$(PHP) $(shell which composer)
+
+# Infection
+INFECTION=build/infection.phar
+MIN_MSI=70
+MIN_COVERED_MSI=80
+INFECTION_ARGS=--min-msi=$(MIN_MSI) --min-covered-msi=$(MIN_COVERED_MSI) --threads=$(JOBS) --coverage=coverage
+
+all: test
+
+##############################################################
+# Continuous Integration                                     #
+##############################################################
+
+ci: SILENT=
+ci: prerequisites ci-phpunit ci-analyze
+	$(SILENT) $(COMPOSER) validate --strict || true
+
+ci-phpunit: ci-cs
+	$(SILENT) $(PHP) $(PHPUNIT) $(PHPUNIT_ARGS)
+	$(SILENT) $(PHP) $(INFECTION) $(INFECTION_ARGS) || true
+
+ci-analyze: ci-cs
+	$(SILENT) $(PHP) $(PHPSTAN) $(PHPSTAN_ARGS) --no-progress || true
+	$(SILENT) $(PHP) $(PHAN) $(PHAN_ARGS) || true
+
+ci-cs: prerequisites
+	$(SILENT) $(PHP) $(PHP_CS_FIXER) $(PHP_CS_FIXER_ARGS) --dry-run --stop-on-violation fix
+
+##############################################################
+# Development Workflow                                       #
+##############################################################
+
+test: phpunit analyze
+	$(SILENT) $(COMPOSER) validate --strict || true
+
+test-prerequisites: prerequisites composer.lock
+
+phpunit: cs
+	$(SILENT) $(PHP) $(PHPUNIT) $(PHPUNIT_ARGS) --verbose
+	$(SILENT) $(PHP) $(INFECTION) $(INFECTION_ARGS) --log-verbosity=2 --show-mutations
+
+analyze: cs
+	$(SILENT) $(PHP) $(PHPSTAN) $(PHPSTAN_ARGS) || true
+	$(SILENT) $(PHP) $(PHAN) $(PHAN_ARGS) --color || true
+
+cs: test-prerequisites
+	$(SILENT) $(PHP) $(PHP_CS_FIXER) $(PHP_CS_FIXER_ARGS) --diff fix
+
+##############################################################
+# Prerequisites Setup                                        #
+##############################################################
+
+# We need both vendor/autoload.php and composer.lock being up to date
+.PHONY: prerequisites
+prerequisites: report-php-version build/cache vendor/autoload.php .phan composer.lock tools
+
+# Do install if there's no 'vendor'
+vendor/autoload.php:
+	$(SILENT) $(COMPOSER) install --prefer-dist
+
+# If composer.lock is older than `composer.json`, do update,
+# and touch composer.lock because composer not always does that
+composer.lock: composer.json
+	$(SILENT) $(COMPOSER) update && touch composer.lock
+
+.phan: $(PHAN)
+	$(PHP) $(PHAN) --init --init-level=1 --init-overwrite --target-php-version=$(PHAN_PHP_VERSION) > /dev/null
+
+build: build/cache
+build/cache:
+	mkdir -p build/cache
+
+.PHONY: report-php-version
+report-php-version:
+	# Using $(PHP)
+
+.PHONY: tools
+tools: $(PHAN) $(PHP_CS_FIXER) $(PHPSTAN) $(INFECTION)
+
+WGET=wget -nv -O
+
+$(PHP_CS_FIXER):
+	mkdir -p build
+	$(WGET) $@ https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+	chmod +x $@
+	touch $@
+
+$(PHPSTAN):
+	mkdir -p build
+	$(WGET) $@ https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
+	chmod +x $@
+	touch $@
+
+$(PHAN):
+	mkdir -p build
+	$(WGET) $@ https://github.com/phan/phan/releases/download/0.12.5/phan.phar
+	chmod +x $@
+	touch $@
+
+$(INFECTION):
+	mkdir -p build
+	$(WGET) $@ https://github.com/infection/infection/releases/download/0.8.0/infection.phar
+	$(WGET) build/infection.phar.pubkey https://github.com/infection/infection/releases/download/0.8.0/infection.phar.pubkey
+	chmod +x build/infection.phar
+
+##############################################################
+# Quick development testing procedure                        #
+##############################################################
+
+PHP_VERSIONS=php7.1 php7.2
+
+.PHONY: quick
+quick:
+	make --no-print-directory -j test-all
+
+.PHONY: test-all
+test-all: $(PHP_VERSIONS)
+
+.PHONY: $(PHP_VERSIONS)
+$(PHP_VERSIONS): cs
+	@make --no-print-directory PHP=$@ PHP_CS_FIXER=/bin/true

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,6 @@
   "require": {
     "php": "^7.1",
     "psr/log": "~1.0",
-    "phpbench/phpbench": "^0.14.0",
-    "squizlabs/php_codesniffer": "*",
     "phpsci/sciboard": "dev-master"
   },
   "suggest": {
@@ -30,6 +28,7 @@
     }
   },
   "require-dev": {
+    "phpbench/phpbench": "^0.14.0",
     "phpunit/phpunit": "^7",
     "phpsci/sciboard": "dev-master"
   }

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     }
   },
   "require-dev": {
-    "phpbench/phpbench": "^0.14.0",
-    "phpunit/phpunit": "^7",
-    "phpsci/sciboard": "dev-master"
+    "phpbench/phpbench": "^0.14",
+    "phpunit/phpunit": "^7"
   }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,11 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection-log.txt"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        bootstrap="vendor/autoload.php"
         colors="true"
         beStrictAboutTestsThatDoNotTestAnything="true"
         beStrictAboutOutputDuringTests="true"

--- a/src/PHPSci/Kernel/CArray/CArrayWrapper.php
+++ b/src/PHPSci/Kernel/CArray/CArrayWrapper.php
@@ -155,7 +155,7 @@ abstract class CArrayWrapper implements Stackable, \ArrayAccess, \Countable
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return MemoryPointer
      */
-    public function ptr() : MemoryPointer
+    public function ptr(): MemoryPointer
     {
         return $this->internal_pointer;
     }

--- a/src/PHPSci/Kernel/CArray/CArrayWrapper.php
+++ b/src/PHPSci/Kernel/CArray/CArrayWrapper.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\CArray;
 
 use PHPSci\Kernel\Initializers\Creatable;

--- a/src/PHPSci/Kernel/CArray/Printable.php
+++ b/src/PHPSci/Kernel/CArray/Printable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\CArray;
 
 /**

--- a/src/PHPSci/Kernel/CArray/Printable.php
+++ b/src/PHPSci/Kernel/CArray/Printable.php
@@ -33,6 +33,7 @@ trait Printable
     public function __toString()
     {
         echo \CArray::print_r($this->ptr()->getPointer(), $this->rows, $this->cols);
+
         return '';
     }
 }

--- a/src/PHPSci/Kernel/CArray/Stackable.php
+++ b/src/PHPSci/Kernel/CArray/Stackable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\CArray;
 
 use PHPSci\Kernel\Orchestrator\MemoryPointer;

--- a/src/PHPSci/Kernel/Exceptions/BroadcastErrorException.php
+++ b/src/PHPSci/Kernel/Exceptions/BroadcastErrorException.php
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace PHPSci\Kernel\Exceptions;
 
 use Throwable;

--- a/src/PHPSci/Kernel/Exceptions/BroadcastErrorException.php
+++ b/src/PHPSci/Kernel/Exceptions/BroadcastErrorException.php
@@ -1,13 +1,18 @@
 <?php
-/**
- * PHP Version 7
- * Class BroadcastError
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Kernel_Exceptions
- * @package  PHPSci\Kernel\Exceptions
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 namespace PHPSci\Kernel\Exceptions;
 

--- a/src/PHPSci/Kernel/Initializers/Creatable.php
+++ b/src/PHPSci/Kernel/Initializers/Creatable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Initializers;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/Initializers/Creatable.php
+++ b/src/PHPSci/Kernel/Initializers/Creatable.php
@@ -36,7 +36,7 @@ trait Creatable
      * @param  int $n Number of rows
      * @return PHPSci
      */
-    public static function identity(int $n) : PHPSci
+    public static function identity(int $n): PHPSci
     {
         return new PHPSci(
             (new IdentityInitializer($n))->run()
@@ -50,11 +50,12 @@ trait Creatable
      * @param  array $shape
      * @return PHPSci
      */
-    public static function zeros(array $shape) : PHPSci
+    public static function zeros(array $shape): PHPSci
     {
         if (!isset($shape[1])) {
             $shape[1] = 0;
         }
+
         return new PHPSci(
             (new ZerosInitializer($shape[0], $shape[1]))->run()
         );

--- a/src/PHPSci/Kernel/Initializers/IdentityInitializer.php
+++ b/src/PHPSci/Kernel/Initializers/IdentityInitializer.php
@@ -34,7 +34,7 @@ class IdentityInitializer extends Initializer
      *
      * @return mixed
      */
-    public function run() : MemoryPointer
+    public function run(): MemoryPointer
     {
         return new MemoryPointer(
             \CArray::identity($this->params[0]),

--- a/src/PHPSci/Kernel/Initializers/IdentityInitializer.php
+++ b/src/PHPSci/Kernel/Initializers/IdentityInitializer.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Initializers;
 
 use PHPSci\Kernel\Orchestrator\MemoryPointer;

--- a/src/PHPSci/Kernel/Initializers/Initializable.php
+++ b/src/PHPSci/Kernel/Initializers/Initializable.php
@@ -32,5 +32,5 @@ interface Initializable
      *
      * @return mixed
      */
-    public function run() : MemoryPointer;
+    public function run(): MemoryPointer;
 }

--- a/src/PHPSci/Kernel/Initializers/Initializable.php
+++ b/src/PHPSci/Kernel/Initializers/Initializable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Initializers;
 
 use PHPSci\Kernel\Orchestrator\MemoryPointer;

--- a/src/PHPSci/Kernel/Initializers/Initializer.php
+++ b/src/PHPSci/Kernel/Initializers/Initializer.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Initializers;
 
 /**

--- a/src/PHPSci/Kernel/Initializers/ZerosInitializer.php
+++ b/src/PHPSci/Kernel/Initializers/ZerosInitializer.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Initializers;
 
 use PHPSci\Kernel\Orchestrator\MemoryPointer;

--- a/src/PHPSci/Kernel/LinearAlgebra/BaseLinalg.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/BaseLinalg.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class BaseLinalg
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Linear_Algebra_Operations
- * @package  PHPSci\Kernel\LinearAlgebra
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\LinearAlgebra;
 
 /**

--- a/src/PHPSci/Kernel/LinearAlgebra/Operatable.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/Operatable.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Trait Operatable
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Linear_Algebra_Operations
- * @package  PHPSci\Kernel\LinearAlgebra
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\LinearAlgebra;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/Kernel/LinearAlgebra/Operatable.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/Operatable.php
@@ -40,7 +40,7 @@ trait Operatable
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return PHPSci
      */
-    public static function matmul(CArrayWrapper $a, CArrayWrapper $b) : PHPSci
+    public static function matmul(CArrayWrapper $a, CArrayWrapper $b): PHPSci
     {
         return new PHPSci(
             (
@@ -58,7 +58,7 @@ trait Operatable
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return PHPSci
      */
-    public static function inner(CArrayWrapper $a, CArrayWrapper $b) : PHPSci
+    public static function inner(CArrayWrapper $a, CArrayWrapper $b): PHPSci
     {
         return new PHPSci(
             (

--- a/src/PHPSci/Kernel/LinearAlgebra/Operation.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/Operation.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Interface Operation
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Linear_Algebra_Operations
- * @package  PHPSci\Kernel\LinearAlgebra
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\LinearAlgebra;
 
 /**

--- a/src/PHPSci/Kernel/LinearAlgebra/Operation.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/Operation.php
@@ -28,5 +28,4 @@ namespace PHPSci\Kernel\LinearAlgebra;
  */
 interface Operation
 {
-
 }

--- a/src/PHPSci/Kernel/LinearAlgebra/ProductOperations.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/ProductOperations.php
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace PHPSci\Kernel\LinearAlgebra;
 
 use PHPSci\Kernel\Orchestrator\MemoryPointer;
@@ -48,7 +49,7 @@ class ProductOperations extends BaseLinalg
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return MemoryPointer
      */
-    public function matmul() : MemoryPointer
+    public function matmul(): MemoryPointer
     {
         $rtn = \CArray::matmul(
             $this->params[0]->ptr()->getUUID(),
@@ -95,7 +96,7 @@ class ProductOperations extends BaseLinalg
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return MemoryPointer
      */
-    public function inner() : MemoryPointer
+    public function inner(): MemoryPointer
     {
         $rtn = \CArray::inner(
             $this->params[0]->ptr()->getUUID(),
@@ -105,6 +106,7 @@ class ProductOperations extends BaseLinalg
             $this->params[1]->ptr()->getRows(),
             $this->params[1]->ptr()->getCols()
         );
+
         return new MemoryPointer(
             $rtn,
             $rtn->x,

--- a/src/PHPSci/Kernel/LinearAlgebra/ProductOperations.php
+++ b/src/PHPSci/Kernel/LinearAlgebra/ProductOperations.php
@@ -1,13 +1,18 @@
 <?php
-/**
- * PHP Version 7
- * Class Product
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Linear_Algebra_Operations
- * @package  PHPSci\Kernel\LinearAlgebra
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 namespace PHPSci\Kernel\LinearAlgebra;
 

--- a/src/PHPSci/Kernel/Math/Arithmetic.php
+++ b/src/PHPSci/Kernel/Math/Arithmetic.php
@@ -1,16 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Trait Arithmetic
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * Allow arithmetic operations with CArrays
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * @category Arithmetic_Operations
- * @package  PHPSci\Kernel\Math
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\Math;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/Kernel/Math/Arithmetic.php
+++ b/src/PHPSci/Kernel/Math/Arithmetic.php
@@ -44,10 +44,10 @@ trait Arithmetic
      * @param CArrayWrapper $b CArray B
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
-     * @return CArrayWrapper The sum of A x B element-wise
      * @throws BroadcastErrorException
+     * @return CArrayWrapper The sum of A x B element-wise
      */
-    public static function add(CArrayWrapper $a, CArrayWrapper $b) : CArrayWrapper
+    public static function add(CArrayWrapper $a, CArrayWrapper $b): CArrayWrapper
     {
         try {
             $result = \CArray::add(
@@ -64,6 +64,7 @@ trait Arithmetic
                 [$b->rows, $b->cols]
             );
         }
+
         return new PHPSci(
             new MemoryPointer(
                 $result,

--- a/src/PHPSci/Kernel/Math/Mathable.php
+++ b/src/PHPSci/Kernel/Math/Mathable.php
@@ -49,7 +49,7 @@ trait Mathable
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return PHPSci
      */
-    public static function sum(CArrayWrapper $a, int $axis = null) : PHPSci
+    public static function sum(CArrayWrapper $a, int $axis = null): PHPSci
     {
         if (!isset($axis)) {
             $out = \CArray::sum(
@@ -66,6 +66,7 @@ trait Mathable
                 $axis
             );
         }
+
         return new PHPSci(
             new MemoryPointer(
                 $out,

--- a/src/PHPSci/Kernel/Math/Mathable.php
+++ b/src/PHPSci/Kernel/Math/Mathable.php
@@ -1,16 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Trait Mathable
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * Allow basic math operations with CArrays
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * @category Basic_Operations
- * @package  PHPSci\Kernel\Math
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\Math;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/Kernel/Orchestrator/MemoryPointer.php
+++ b/src/PHPSci/Kernel/Orchestrator/MemoryPointer.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Orchestrator;
 
 /**

--- a/src/PHPSci/Kernel/Orchestrator/MemoryPointer.php
+++ b/src/PHPSci/Kernel/Orchestrator/MemoryPointer.php
@@ -87,7 +87,7 @@ class MemoryPointer
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public function getRows() : int
+    public function getRows(): int
     {
         return $this->x;
     }
@@ -97,7 +97,7 @@ class MemoryPointer
      *
      * @return int
      */
-    public function getCols() : int
+    public function getCols(): int
     {
         return $this->y;
     }

--- a/src/PHPSci/Kernel/Orchestrator/MemoryStack.php
+++ b/src/PHPSci/Kernel/Orchestrator/MemoryStack.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Orchestrator;
 
 /**

--- a/src/PHPSci/Kernel/Orchestrator/MemoryStack.php
+++ b/src/PHPSci/Kernel/Orchestrator/MemoryStack.php
@@ -24,5 +24,4 @@ namespace PHPSci\Kernel\Orchestrator;
  */
 class MemoryStack
 {
-
 }

--- a/src/PHPSci/Kernel/PropertiesProcessor/Inflatable.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/Inflatable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 /**

--- a/src/PHPSci/Kernel/PropertiesProcessor/PropertiesProcessor.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/PropertiesProcessor.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 /**

--- a/src/PHPSci/Kernel/PropertiesProcessor/PropertiesProcessor.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/PropertiesProcessor.php
@@ -24,5 +24,4 @@ namespace PHPSci\Kernel\PropertiesProcessor;
  */
 abstract class PropertiesProcessor implements Property
 {
-
 }

--- a/src/PHPSci/Kernel/PropertiesProcessor/Property.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/Property.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/PropertiesProcessor/cols.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/cols.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/PropertiesProcessor/rows.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/rows.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/PropertiesProcessor/sizeOf.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/sizeOf.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/PropertiesProcessor/took.php
+++ b/src/PHPSci/Kernel/PropertiesProcessor/took.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\PropertiesProcessor;
 
 use PHPSci\PHPSci;

--- a/src/PHPSci/Kernel/Ranges/Rangeable.php
+++ b/src/PHPSci/Kernel/Ranges/Rangeable.php
@@ -57,8 +57,9 @@ trait Rangeable
         float $stop,
         float $start = 0.,
         float $step = 1.
-    ) : CArrayWrapper {
+    ): CArrayWrapper {
         $new_ptr = \CArray::arange($start, $stop, $step);
+
         return new PHPSci(
             new MemoryPointer(
                 $new_ptr,
@@ -85,8 +86,9 @@ trait Rangeable
         float $start,
         float $stop,
         float $num = 50
-    ) : CArrayWrapper {
+    ): CArrayWrapper {
         $new_ptr = \CArray::linspace($start, $stop, $num);
+
         return new PHPSci(
             new MemoryPointer(
                 $new_ptr,
@@ -112,8 +114,9 @@ trait Rangeable
         float $stop,
         int $num = 50,
         float $base = 10
-    ) : CArrayWrapper {
+    ): CArrayWrapper {
         $new_ptr = \CArray::logspace($start, $stop, $num, $base);
+
         return new PHPSci(
             new MemoryPointer(
                 $new_ptr,

--- a/src/PHPSci/Kernel/Ranges/Rangeable.php
+++ b/src/PHPSci/Kernel/Ranges/Rangeable.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Trait Rangeable
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Ranges
- * @package  PHPSci\Kernel\Ranges
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Kernel\Ranges;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/Kernel/Transform/Transformable.php
+++ b/src/PHPSci/Kernel/Transform/Transformable.php
@@ -34,9 +34,10 @@ trait Transformable
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public static function fromArray(array $arr) : PHPSci
+    public static function fromArray(array $arr): PHPSci
     {
         $ptr = \CArray::fromArray($arr);
+
         return new PHPSci(new MemoryPointer($ptr, $ptr->x, $ptr->y));
     }
 
@@ -67,9 +68,10 @@ trait Transformable
      * @param  float $input
      * @return CArrayWrapper
      */
-    public static function fromDouble(float $input) : CArrayWrapper
+    public static function fromDouble(float $input): CArrayWrapper
     {
         $ptr = \CArray::fromDouble($input);
+
         return new PHPSci((new MemoryPointer($ptr, $ptr->x, $ptr->y)));
     }
 
@@ -82,7 +84,7 @@ trait Transformable
      * @param  PHPSci $obj
      * @return array
      */
-    public static function asarray(PHPSci $obj) : array
+    public static function asarray(PHPSci $obj): array
     {
         return $obj->toArray();
     }
@@ -90,13 +92,14 @@ trait Transformable
     /**
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public static function transpose(CArrayWrapper $arr) : CArrayWrapper
+    public static function transpose(CArrayWrapper $arr): CArrayWrapper
     {
         $rtn_carray = \CArray::transpose(
             $arr->ptr()->getUUID(),
             $arr->ptr()->getRows(),
             $arr->ptr()->getCols()
         );
+
         return new PHPSci(
             new MemoryPointer(
                 $rtn_carray,

--- a/src/PHPSci/Kernel/Transform/Transformable.php
+++ b/src/PHPSci/Kernel/Transform/Transformable.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Kernel\Transform;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/PHPSci.php
+++ b/src/PHPSci/PHPSci.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;

--- a/src/PHPSci/PHPSci.php
+++ b/src/PHPSci/PHPSci.php
@@ -19,7 +19,6 @@ namespace PHPSci;
 
 use PHPSci\Kernel\CArray\CArrayWrapper;
 use PHPSci\Kernel\Orchestrator\MemoryPointer;
-use PHPSci\Kernel\Printable;
 
 /**
  * Main PHPSci Object
@@ -31,11 +30,13 @@ class PHPSci extends CArrayWrapper
 {
     /**
      * PHPSci constructor.
+     * @param mixed $input
      */
     public function __construct($input)
     {
         if (is_object($input) && get_class($input) == "PHPSci\Kernel\Orchestrator\MemoryPointer") {
             $this->internal_pointer = $input;
+
             return;
         }
         if (is_array($input)) {
@@ -45,6 +46,7 @@ class PHPSci extends CArrayWrapper
                 $new_carray->ptr()->getRows(),
                 $new_carray->ptr()->getCols()
             );
+
             return;
         }
         if (is_double($input) || is_int($input) || is_float($input)) {
@@ -54,6 +56,7 @@ class PHPSci extends CArrayWrapper
                 $new_carray->ptr()->getRows(),
                 $new_carray->ptr()->getCols()
             );
+
             return;
         }
     }

--- a/tests/Initializers/ArrayConvertTest.php
+++ b/tests/Initializers/ArrayConvertTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class ArrayConvertTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Initializers
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Initializers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Initializers/ArrayConvertTest.php
+++ b/tests/Initializers/ArrayConvertTest.php
@@ -17,8 +17,8 @@
 
 namespace PHPSci\Tests\Initializers;
 
-use PHPUnit\Framework\TestCase;
 use PHPSci\PHPSci as ps;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ArrayConvertTest
@@ -31,7 +31,6 @@ use PHPSci\PHPSci as ps;
  */
 class ArrayConvertTest extends TestCase
 {
-
     /**
      * Test fromArray() with 2D array
      *
@@ -40,7 +39,7 @@ class ArrayConvertTest extends TestCase
      */
     public function testFromArray2D()
     {
-        $a = ps::fromArray([[1,0,1,0],[0,1,0,1]]);
+        $a = ps::fromArray([[1, 0, 1, 0], [0, 1, 0, 1]]);
         $this->assertObjectNotHasAttribute('uuid', $a);
     }
 
@@ -52,7 +51,7 @@ class ArrayConvertTest extends TestCase
      */
     public function testToArray2D()
     {
-        $parr = [[1,0,1,0],[0,1,0,1]];
+        $parr = [[1, 0, 1, 0], [0, 1, 0, 1]];
         $a = ps::fromArray($parr);
         $b = $a->toArray();
         $this->assertObjectNotHasAttribute('uuid', $a);
@@ -67,7 +66,7 @@ class ArrayConvertTest extends TestCase
      */
     public function testFromArray1D()
     {
-        $a = ps::fromArray([1,0,1,0,0,1,0,1]);
+        $a = ps::fromArray([1, 0, 1, 0, 0, 1, 0, 1]);
         $this->assertObjectNotHasAttribute('uuid', $a);
     }
 
@@ -79,7 +78,7 @@ class ArrayConvertTest extends TestCase
      */
     public function testToArray1D()
     {
-        $parr = [1,0,1,0,0,1,0,1];
+        $parr = [1, 0, 1, 0, 0, 1, 0, 1];
         $a = ps::fromArray($parr);
         $b = ps::asarray($a);
         $this->assertObjectNotHasAttribute('uuid', $a);
@@ -112,5 +111,4 @@ class ArrayConvertTest extends TestCase
         $this->assertObjectNotHasAttribute('uuid', $a);
         $this->assertEquals($parr, $b);
     }
-
 }

--- a/tests/Initializers/IdentityTest.php
+++ b/tests/Initializers/IdentityTest.php
@@ -31,14 +31,13 @@ use PHPUnit\Framework\TestCase;
  */
 class IdentityTest extends TestCase
 {
-
     /**
      * Test big Identity Creation
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return void
      */
-    public function testCreateBigIdentity() : void
+    public function testCreateBigIdentity(): void
     {
         $wanted = [
             [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -53,9 +52,8 @@ class IdentityTest extends TestCase
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
         ];
         $generated = PHPSci::identity(10)->toArray();
-        $this->assertEquals($wanted, (array)$generated);
+        $this->assertEquals($wanted, (array) $generated);
     }
-
 
     /**
      * Test small Identity Creation
@@ -63,14 +61,13 @@ class IdentityTest extends TestCase
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
      * @return void
      */
-    public function testCreateSmallIdentity() : void
+    public function testCreateSmallIdentity(): void
     {
         $wanted = [
             [1, 0],
             [0, 1],
         ];
         $generated = PHPSci::identity(2)->toArray();
-        $this->assertEquals($wanted, (array)$generated);
+        $this->assertEquals($wanted, (array) $generated);
     }
-
 }

--- a/tests/Initializers/IdentityTest.php
+++ b/tests/Initializers/IdentityTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class Identity
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Initializers
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Initializers;
 
 use PHPSci\PHPSci;

--- a/tests/Initializers/ZerosTest.php
+++ b/tests/Initializers/ZerosTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class ZerosTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Initializers
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Initializers;
 
 use PHPSci\PHPSci;

--- a/tests/Initializers/ZerosTest.php
+++ b/tests/Initializers/ZerosTest.php
@@ -40,11 +40,11 @@ class ZerosTest extends TestCase
     public function testCreateSmallZeros()
     {
         $wanted = [
-            [ 0 , 0 ],
-            [ 0 , 0 ],
-            [ 0 , 0 ]
+            [0, 0],
+            [0, 0],
+            [0, 0],
         ];
-        $generated = PHPSci::zeros([3,2])->toArray();
+        $generated = PHPSci::zeros([3, 2])->toArray();
         $this->assertEquals($wanted, $generated);
     }
 
@@ -57,10 +57,10 @@ class ZerosTest extends TestCase
     public function testCreateSquareZeros()
     {
         $wanted = [
-            [ 0 , 0 ],
-            [ 0 , 0 ]
+            [0, 0],
+            [0, 0],
         ];
-        $generated = PHPSci::zeros([2,2])->toArray();
+        $generated = PHPSci::zeros([2, 2])->toArray();
         $this->assertEquals($wanted, $generated);
     }
 
@@ -73,19 +73,18 @@ class ZerosTest extends TestCase
     public function testCreateBigZeros()
     {
         $wanted = [
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
-            [ 0 , 0, 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ]
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         ];
-        $generated = PHPSci::zeros([10,10])->toArray();
+        $generated = PHPSci::zeros([10, 10])->toArray();
         $this->assertEquals($wanted, $generated);
     }
 }
-

--- a/tests/LinearAlgebra/InnerProductTest.php
+++ b/tests/LinearAlgebra/InnerProductTest.php
@@ -30,7 +30,7 @@ class InnerProductTest extends TestCase
     /**
      * @author   Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public function testInner1Dv0D ()
+    public function testInner1Dv0D()
     {
         $expected = [7, 14, 7];
         $a = ps::fromArray([1, 2, 1]);
@@ -41,7 +41,7 @@ class InnerProductTest extends TestCase
     /**
      * @author   Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public function testInner1Dv1D ()
+    public function testInner1Dv1D()
     {
         $expected = 2;
         $a = ps::fromArray([1, 2, 3]);
@@ -52,11 +52,11 @@ class InnerProductTest extends TestCase
     /**
      * @author   Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public function testInner2Dv0D ()
+    public function testInner2Dv0D()
     {
         $expected = [
             [7, 0],
-            [0, 7]
+            [0, 7],
         ];
         $a = ps::identity(2);
         $b = ps::fromDouble(7);
@@ -66,14 +66,14 @@ class InnerProductTest extends TestCase
     /**
      * @author   Henrique Borba <henrique.borba.dev@gmail.com>
      */
-    public function testInner2Dv2D ()
+    public function testInner2Dv2D()
     {
         $expected = [
             [6, 10],
-            [7, 13]
+            [7, 13],
         ];
-        $a = ps::fromArray([[1,2,1],[1,3,1]]);
-        $b = ps::fromArray([[2,1,2],[2,3,2]]);
+        $a = ps::fromArray([[1, 2, 1], [1, 3, 1]]);
+        $b = ps::fromArray([[2, 1, 2], [2, 3, 2]]);
         $this->assertEquals($expected, ps::inner($a, $b)->toArray());
     }
 }

--- a/tests/LinearAlgebra/InnerProductTest.php
+++ b/tests/LinearAlgebra/InnerProductTest.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace PHPSci\Tests\LinearAlgebra;
 
 use PHPSci\PHPSci as ps;

--- a/tests/LinearAlgebra/MatmulTest.php
+++ b/tests/LinearAlgebra/MatmulTest.php
@@ -18,8 +18,8 @@
 namespace PHPSci\Tests\LinearAlgebra;
 
 use PHPSci\PHPSci;
-use PHPUnit\Framework\TestCase;
 use PHPSci\PHPSci as ps;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MatmulTest
@@ -32,7 +32,6 @@ use PHPSci\PHPSci as ps;
  */
 class MatmulTest extends TestCase
 {
-
     /**
      * Test (2,3) * (3,2) dot product using matmul
      *
@@ -43,10 +42,10 @@ class MatmulTest extends TestCase
     {
         $expected = [
             [58, 64],
-            [139, 154]
+            [139, 154],
         ];
-        $a = ps::fromArray([[1,2,3],[4,5,6]]);
-        $b = ps::fromArray([[7,8],[9,10],[11,12]]);
+        $a = ps::fromArray([[1, 2, 3], [4, 5, 6]]);
+        $b = ps::fromArray([[7, 8], [9, 10], [11, 12]]);
         $returned = ps::matmul($a, $b);
         $this->assertEquals($expected, $returned->toArray());
     }
@@ -63,7 +62,6 @@ class MatmulTest extends TestCase
         $expected = $a->toArray();
         $result = ps::matmul($a, $a)->toArray();
         $this->assertEquals($expected, $result);
-
     }
 
     /**
@@ -88,10 +86,10 @@ class MatmulTest extends TestCase
      */
     public function testMatmul2D1D()
     {
-        $expected = [30,33,51,24];
-        $expected_2 = [19,45,24,41];
-        $a = PHPSci::fromArray([[1,2,3,4],[4,9,1,2],[2,3,5,7],[1,4,1,3]]);
-        $b = PHPSci::fromArray([1,2,3,4]);
+        $expected = [30, 33, 51, 24];
+        $expected_2 = [19, 45, 24, 41];
+        $a = PHPSci::fromArray([[1, 2, 3, 4], [4, 9, 1, 2], [2, 3, 5, 7], [1, 4, 1, 3]]);
+        $b = PHPSci::fromArray([1, 2, 3, 4]);
         $this->assertEquals($expected, ps::matmul($a, $b)->toArray());
         $this->assertEquals($expected_2, ps::matmul($b, $a)->toArray());
     }
@@ -105,11 +103,8 @@ class MatmulTest extends TestCase
     public function testMatmul1D1D()
     {
         $expected = 33;
-        $a = PHPSci::fromArray([1,2,3,4]);
-        $b = PHPSci::fromArray([4,9,1,2]);
+        $a = PHPSci::fromArray([1, 2, 3, 4]);
+        $b = PHPSci::fromArray([4, 9, 1, 2]);
         $this->assertEquals($expected, ps::matmul($a, $b)->toDouble());
     }
-
-
-
 }

--- a/tests/LinearAlgebra/MatmulTest.php
+++ b/tests/LinearAlgebra/MatmulTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class MatmulTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\LinearAlgebra
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\LinearAlgebra;
 
 use PHPSci\PHPSci;

--- a/tests/Math/ArithmeticTest.php
+++ b/tests/Math/ArithmeticTest.php
@@ -17,9 +17,7 @@
 
 namespace PHPSci\Tests\Math;
 
-use PHPSci\Kernel\Exceptions\BroadcastError;
 use PHPSci\PHPSci as ps;
-use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -37,8 +35,8 @@ class ArithmeticTest extends TestCase
      * Check add() with scalars
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
-     * @return void
      * @throws \PHPSci\Kernel\Exceptions\BroadcastErrorException
+     * @return void
      */
     public function testAddScalars()
     {
@@ -54,21 +52,21 @@ class ArithmeticTest extends TestCase
      * Test add with 1D matrices
      *
      * @author Henrique Borba <henrique.borba.dev@gmail.com>
-     * @return void
      * @throws \PHPSci\Kernel\Exceptions\BroadcastErrorException
+     * @return void
      */
     public function testAdd1D()
     {
-        $expected = [2,3,4,5];
+        $expected = [2, 3, 4, 5];
 
-        $a = ps::fromArray([1,2,3,4]);
+        $a = ps::fromArray([1, 2, 3, 4]);
         $b = ps::fromDouble(1);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $expected = [2,4,6,8];
+        $expected = [2, 4, 6, 8];
 
-        $a = ps::fromArray([1,2,3,4]);
+        $a = ps::fromArray([1, 2, 3, 4]);
 
         $this->assertEquals($expected, ps::add($a, $a)->toArray());
     }
@@ -77,43 +75,43 @@ class ArithmeticTest extends TestCase
      * Test add() with 2D matrices
      *
      * @author            Henrique Borba <henrique.borba.dev@gmail.com>
-     * @expectedException PHPSci\Kernel\Exceptions\BroadcastErrorException
-     * @return            void
+     * @expectedException \PHPSci\Kernel\Exceptions\BroadcastErrorException
      * @throws            \PHPSci\Kernel\Exceptions\BroadcastErrorException
+     * @return            void
      */
     public function testAdd2D()
     {
-        $expected = [[2,3,4,5]];
+        $expected = [[2, 3, 4, 5]];
 
-        $a = ps::fromArray([[1,2,3,4]]);
+        $a = ps::fromArray([[1, 2, 3, 4]]);
         $b = ps::fromDouble(1);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $a = ps::fromArray([[1,2,3,4]]);
-        $b = ps::fromArray([1,1,1,1]);
+        $a = ps::fromArray([[1, 2, 3, 4]]);
+        $b = ps::fromArray([1, 1, 1, 1]);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $a = ps::fromArray([[1,2,3,4]]);
-        $b = ps::fromArray([[1,1,1,1]]);
+        $a = ps::fromArray([[1, 2, 3, 4]]);
+        $b = ps::fromArray([[1, 1, 1, 1]]);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $expected = [[2,3,4,5],[2,3,4,5]];
-        $a = ps::fromArray([[1,2,3,4],[1,2,3,4]]);
-        $b = ps::fromArray([[1,1,1,1]]);
+        $expected = [[2, 3, 4, 5], [2, 3, 4, 5]];
+        $a = ps::fromArray([[1, 2, 3, 4], [1, 2, 3, 4]]);
+        $b = ps::fromArray([[1, 1, 1, 1]]);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $expected = [[2,3,4,5],[2,3,4,5]];
-        $a = ps::fromArray([[1,2,3,4],[1,2,3,4]]);
-        $b = ps::fromArray([[1,1,1,1],[1,1,1,1]]);
+        $expected = [[2, 3, 4, 5], [2, 3, 4, 5]];
+        $a = ps::fromArray([[1, 2, 3, 4], [1, 2, 3, 4]]);
+        $b = ps::fromArray([[1, 1, 1, 1], [1, 1, 1, 1]]);
 
         $this->assertEquals($expected, ps::add($a, $b)->toArray());
 
-        $a = ps::fromArray([[1,2,3,4],[1,2,3,4],[1,2,3,4]]);
-        $b = ps::fromArray([[1,1,1,1],[1,1,1,1]]);
+        $a = ps::fromArray([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]);
+        $b = ps::fromArray([[1, 1, 1, 1], [1, 1, 1, 1]]);
         ps::add($a, $b);
     }
 }

--- a/tests/Math/ArithmeticTest.php
+++ b/tests/Math/ArithmeticTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class ArithmeticTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Math
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Math;
 
 use PHPSci\Kernel\Exceptions\BroadcastError;

--- a/tests/Math/BasicOperationsTest.php
+++ b/tests/Math/BasicOperationsTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class BasicOperationsTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Math
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Math;
 
 use PHPSci\PHPSci as ps;

--- a/tests/Math/BasicOperationsTest.php
+++ b/tests/Math/BasicOperationsTest.php
@@ -31,7 +31,6 @@ use PHPUnit\Framework\TestCase;
  */
 class BasicOperationsTest extends TestCase
 {
-
     /**
      * Test basic sum with axis = null
      *
@@ -54,16 +53,14 @@ class BasicOperationsTest extends TestCase
      */
     public function testBasicSumAxis()
     {
-        $expected_y = [0,6];
-        $expected_x = [1,5];
+        $expected_y = [0, 6];
+        $expected_x = [1, 5];
 
-        $carray = ps::fromArray([[0,1], [0,5]]);
+        $carray = ps::fromArray([[0, 1], [0, 5]]);
         $result_y = ps::sum($carray, 0);
         $result_x = ps::sum($carray, 1);
 
         $this->assertEquals($expected_y, $result_y->toArray());
         $this->assertEquals($expected_x, $result_x->toArray());
     }
-
-
 }

--- a/tests/Performance/Initializers/IdentityBench.php
+++ b/tests/Performance/Initializers/IdentityBench.php
@@ -31,11 +31,8 @@ use PHPSci\PHPSci;
  */
 class IdentityBench
 {
-
-
-    public function init() : void
+    public function init(): void
     {
-
     }
 
     /**
@@ -55,5 +52,4 @@ class IdentityBench
     {
         $a = PHPSci::identity(100);
     }
-
 }

--- a/tests/Performance/Initializers/IdentityBench.php
+++ b/tests/Performance/Initializers/IdentityBench.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare(strict_types=1);
 
 namespace PHPSci\Tests\Perfomance\Initializers;

--- a/tests/Performance/Initializers/MatmulBench.php
+++ b/tests/Performance/Initializers/MatmulBench.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class MatmulBench
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Benchmark
- * @package  PHPSci\Tests\Performance\Initializers
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 declare(strict_types=1);
 namespace PHPSci\Tests\Perfomance\Initializers;
 

--- a/tests/Performance/Initializers/MatmulBench.php
+++ b/tests/Performance/Initializers/MatmulBench.php
@@ -16,6 +16,7 @@
  */
 
 declare(strict_types=1);
+
 namespace PHPSci\Tests\Perfomance\Initializers;
 
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
@@ -37,7 +38,6 @@ use PHPSci\PHPSci;
  */
 class MatmulBench
 {
-
     public $matrix_a_bb;
     public $matrix_b_bb;
     public $matrix_a_b;
@@ -49,7 +49,7 @@ class MatmulBench
      * @author   Henrique Borba <henrique.borba.dev@gmail.com>
      * @return void
      */
-    public function init() : void 
+    public function init(): void
     {
         $this->matrix_a_bb = PHPSci::identity(5000);
         $this->matrix_b_bb = PHPSci::identity(5000);
@@ -63,17 +63,7 @@ class MatmulBench
      * @Revs(1)
      * @Iterations(5)
      */
-    public function benchReallyBigMatmul() 
-    {
-        $r = PHPSci::matmul($this->matrix_a_b, $this->matrix_b_b);
-    }
-
-
-    /**
-     * @Revs(1)
-     * @Iterations(5)
-     */
-    public function benchBigMatmul() 
+    public function benchReallyBigMatmul()
     {
         $r = PHPSci::matmul($this->matrix_a_b, $this->matrix_b_b);
     }
@@ -82,9 +72,17 @@ class MatmulBench
      * @Revs(1)
      * @Iterations(5)
      */
-    public function benchSmallMatmul() 
+    public function benchBigMatmul()
+    {
+        $r = PHPSci::matmul($this->matrix_a_b, $this->matrix_b_b);
+    }
+
+    /**
+     * @Revs(1)
+     * @Iterations(5)
+     */
+    public function benchSmallMatmul()
     {
         $r = PHPSci::matmul($this->matrix_a_s, $this->matrix_b_s);
     }
-
 }

--- a/tests/Performance/bootstrap.php
+++ b/tests/Performance/bootstrap.php
@@ -1,4 +1,20 @@
 <?php
+/*
+ * Copyright 2018 Henrique Borba and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare(strict_types=1);
 
 require __DIR__.'/../../vendor/autoload.php';

--- a/tests/Ranges/ArangeTest.php
+++ b/tests/Ranges/ArangeTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class ArangeTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Ranges
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Ranges;
 
 use PHPSci\PHPSci as ps;

--- a/tests/Ranges/ArangeTest.php
+++ b/tests/Ranges/ArangeTest.php
@@ -42,10 +42,10 @@ class ArangeTest extends TestCase
         $expected = [0, 1, 2];
         $this->assertEquals($expected, ps::arange(3)->toArray());
 
-        $expected = [3,4,5,6];
+        $expected = [3, 4, 5, 6];
         $this->assertEquals($expected, ps::arange(7, 3)->toArray());
 
-        $expected = [3,5];
+        $expected = [3, 5];
         $this->assertEquals($expected, ps::arange(7, 3, 2)->toArray());
     }
 }

--- a/tests/Ranges/LinspaceTest.php
+++ b/tests/Ranges/LinspaceTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class LinspaceTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Ranges
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Ranges;
 
 use PHPSci\PHPSci;

--- a/tests/Ranges/LinspaceTest.php
+++ b/tests/Ranges/LinspaceTest.php
@@ -38,7 +38,7 @@ class LinspaceTest extends TestCase
      */
     public function testSmallLinspace()
     {
-        $expected = [2.  ,  2.25,  2.5 ,  2.75,  3.];
+        $expected = [2.,  2.25,  2.5,  2.75,  3.];
         $this->assertEquals($expected, PHPSci::linspace(2, 3, 5)->toArray());
     }
 }

--- a/tests/Ranges/LogspaceTest.php
+++ b/tests/Ranges/LogspaceTest.php
@@ -1,14 +1,20 @@
 <?php
-/**
- * PHP Version 7
- * Class LogspaceTest
+/*
+ * Copyright 2018 Henrique Borba and contributors
  *
- * @category Test
- * @package  PHPSci\Tests\Ranges
- * @author   Henrique Borba <henrique.borba.dev@gmail.com>
- * @license  Apache 2.0
- * @link     https://www.github.com/phpsci/phpsci
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 namespace PHPSci\Tests\Ranges;
 
 use PHPSci\PHPSci;


### PR DESCRIPTION
* CI/CS changed to use Makefile, no need to remember any commands - just type `make` and everything is done for you.
* Deprecating PHP_CodeSniffer in favor of superior PHP-CS-Fixer; the latter won't scold poor coding practice, but instead fix all CS violations for you. You can code as you like, forget about cleaning imports, etc. 
* Added a license header to all files, [required by the license](https://github.com/phpsci/phpsci/blob/master/LICENSE#L178).
* Added two static analyzers in a recommendation mode, and mutation testing tool - it will automatically tell if tests isn't good enough. These are not causing a build failure yet.

Please let me know if this change is to your liking. I tried to keep code change to minimum to simplify review, more drastic changes will be coming next for a closer inspection.